### PR TITLE
Supports gz sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gazebo_apriltag
+# gazebo_apriltag for gz sim
 
 **For Gazebo harmonic use: https://github.com/rickarmstrong/gazebo_apriltag/tree/harmonic**
 
@@ -7,6 +7,10 @@
 Install models by running:
 ```bash
 cp -R gazebo_apriltag/models/* ~/.gazebo/models/
+```
+or
+```shell
+export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:/path/to/models
 ```
 
 Or, add the full path to `gazebo_apriltag/models/` to the `GAZEBO_MODEL_PATH` environment variable.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ or
 ```shell
 export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:/path/to/models
 ```
-
-Or, add the full path to `gazebo_apriltag/models/` to the `GAZEBO_MODEL_PATH` environment variable.
-
 Generate additional tag models:
 ```bash
 # Edit the following lines in generate.py to create tag models you want

--- a/models/Apriltag36_11_00000/model.sdf
+++ b/models/Apriltag36_11_00000/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00000/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00000/materials/textures</uri>
-            <name>Apriltag36_11_00000</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00000/materials/textures/tag36_11_00000.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00001/model.sdf
+++ b/models/Apriltag36_11_00001/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00001/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00001/materials/textures</uri>
-            <name>Apriltag36_11_00001</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00001/materials/textures/tag36_11_00001.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00002/model.sdf
+++ b/models/Apriltag36_11_00002/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00002/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00002/materials/textures</uri>
-            <name>Apriltag36_11_00002</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00002/materials/textures/tag36_11_00002.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00003/model.sdf
+++ b/models/Apriltag36_11_00003/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00003/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00003/materials/textures</uri>
-            <name>Apriltag36_11_00003</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00003/materials/textures/tag36_11_00003.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00004/model.sdf
+++ b/models/Apriltag36_11_00004/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00004/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00004/materials/textures</uri>
-            <name>Apriltag36_11_00004</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00004/materials/textures/tag36_11_00004.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00005/model.sdf
+++ b/models/Apriltag36_11_00005/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00005/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00005/materials/textures</uri>
-            <name>Apriltag36_11_00005</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00005/materials/textures/tag36_11_00005.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00006/model.sdf
+++ b/models/Apriltag36_11_00006/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00006/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00006/materials/textures</uri>
-            <name>Apriltag36_11_00006</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00006/materials/textures/tag36_11_00006.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00007/model.sdf
+++ b/models/Apriltag36_11_00007/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00007/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00007/materials/textures</uri>
-            <name>Apriltag36_11_00007</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00007/materials/textures/tag36_11_00007.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00008/model.sdf
+++ b/models/Apriltag36_11_00008/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00008/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00008/materials/textures</uri>
-            <name>Apriltag36_11_00008</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00008/materials/textures/tag36_11_00008.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00009/model.sdf
+++ b/models/Apriltag36_11_00009/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00009/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00009/materials/textures</uri>
-            <name>Apriltag36_11_00009</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00009/materials/textures/tag36_11_00009.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00010/model.sdf
+++ b/models/Apriltag36_11_00010/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00010/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00010/materials/textures</uri>
-            <name>Apriltag36_11_00010</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00010/materials/textures/tag36_11_00010.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00011/model.sdf
+++ b/models/Apriltag36_11_00011/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00011/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00011/materials/textures</uri>
-            <name>Apriltag36_11_00011</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00011/materials/textures/tag36_11_00011.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00012/model.sdf
+++ b/models/Apriltag36_11_00012/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00012/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00012/materials/textures</uri>
-            <name>Apriltag36_11_00012</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00012/materials/textures/tag36_11_00012.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00013/model.sdf
+++ b/models/Apriltag36_11_00013/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00013/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00013/materials/textures</uri>
-            <name>Apriltag36_11_00013</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00013/materials/textures/tag36_11_00013.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00014/model.sdf
+++ b/models/Apriltag36_11_00014/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00014/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00014/materials/textures</uri>
-            <name>Apriltag36_11_00014</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00014/materials/textures/tag36_11_00014.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/models/Apriltag36_11_00015/model.sdf
+++ b/models/Apriltag36_11_00015/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00015/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00015/materials/textures</uri>
-            <name>Apriltag36_11_00015</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00015/materials/textures/tag36_11_00015.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>

--- a/template/model.sdf
+++ b/template/model.sdf
@@ -6,15 +6,21 @@
       <visual name='main_Visual'>
         <geometry>
           <box>
-          <size>1.0 1.0 0.01</size>
+            <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-           <material>
+        <material>
           <script>
-            <uri>model://Apriltag36_11_00000/materials/scripts</uri>
-            <uri>model://Apriltag36_11_00000/materials/textures</uri>
-            <name>Apriltag36_11_00000</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/White</name>
           </script>
+          <pbr>
+            <metal>
+              <albedo_map>model://Apriltag36_11_00000/materials/textures/tag36_11_00000.png</albedo_map>
+              <metalness>0.0</metalness>
+              <roughness>0.5</roughness>
+            </metal>
+          </pbr>
         </material>
       </visual>
      </link>


### PR DESCRIPTION
I have updated the models to now support gz sim, which doesn't support material script and running this in docker has some issues, fixed that. just have to do 
```shell
export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:/path/to/models  
 ```
or add to `bashrc`